### PR TITLE
set deepcopy and quirky exceptions for >=1.7

### DIFF
--- a/build/configBase.nims
+++ b/build/configBase.nims
@@ -114,6 +114,10 @@ proc getNimFlags*(fo: flagsOpts): seq[string] =
   warning[SmallLshouldNotBeUsed] ~ off
   embedsrc ~ ""
 
+  if (NimMajor, NimMinor) >= (1, 7):
+    deepcopy ~ on
+    exceptions ~ quirky
+
   if not fo.debug:
     d ~ "release"
     d ~ "danger"


### PR DESCRIPTION
These two parameters allow Nim devel branch to compile QEX, rather slowly.  The reason for deepcopy behind a compiler switch is not clear to me.  Quirky exceptions, being very lightweight, uses a thread local global variable to indicate exceptions, but otherwise does not change control flow.

Wait until Nim v1.7 releases and see how this works.