### PR TITLE
rng: avoid extreme values in gaussian

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,22 +45,16 @@ jobs:
         repository: nim-lang/Nim
         ref: ${{ matrix.nim-branch }}
         path: Nim
-    - name: checkout Nim csources
-      uses: actions/checkout@v3
-      with:
-        repository: nim-lang/csources_v1
-        path: Nim/csources
     - name: set path to nim
       run: echo "${{ github.workspace }}/Nim/bin" >> $GITHUB_PATH
-    - name: build Nim csources
-      working-directory: Nim/csources
-      run: make -j $(nproc)
     - name: build Nim & nimble
       working-directory: Nim
       run: |
-        nim c koch
-        ./koch boot -d:release -d:danger
-        ./koch nimble -d:release -d:danger
+        . ci/funs.sh
+        nimBuildCsourcesIfNeeded
+        ./bin/nim c --noNimblePath --skipUserCfg --skipParentCfg --hints:off koch
+        ./koch boot -d:release -d:danger --skipUserCfg --skipParentCfg --hints:off
+        ./koch nimble -d:release -d:danger --skipUserCfg --skipParentCfg --hints:off
     - name: checkout
       uses: actions/checkout@v3
       with:

--- a/src/rng/milcrng.nim
+++ b/src/rng/milcrng.nim
@@ -148,14 +148,15 @@ proc gaussian*(prn: var RngMilc6): float32 =
       result = prn.gset
   else:
     const
-      TINY = 9.999999999999999e-308
+      MAX = 0x01000000.float
+      SCALE1 = 1.0 / (MAX + 1.0)
     var
       v: cdouble
       p: cdouble
       r: cdouble
-    v = prn.uniform
+    v = SCALE1 * (prn.uniform * MAX + 1.0)
     p = prn.uniform * 2.0 * PI
-    r = sqrt(-2.0 * ln(v + TINY))
+    r = sqrt(-2.0 * ln(v))
     result = r * cos(p)
 
 # Only needed for non-vectorized RNGs.

--- a/src/rng/mrg32k3a.nim
+++ b/src/rng/mrg32k3a.nim
@@ -120,6 +120,7 @@ proc seed*(prn: var MRG32k3a; sed,index: auto) {.inline.} =
   seedIndep(prn, ss, index)
 
 proc uniform*(prn:var MRG32k3a):float =
+  ## Uniform random numbers from 0 to 1, excluding 0 and 1.
   var p1,p2:float
   p1 = a12 * prn.s1[1].float - a13n * prn.s1[0].float
   p1 = p1 mod m1
@@ -145,11 +146,11 @@ proc uniform*(prn:var MRG32k3a):float =
 proc gaussian*(prn: var MRG32k3a): float =
   ## Gaussian normal deviate
   ## Probability distribution exp( -x*x/2 ), so < x^2 > = 1
-  const TINY = 9.999999999999999e-308
+  # uniform excludes 0 and 1
   var v,p,r: float
   v = prn.uniform
   p = prn.uniform * 2.0 * PI
-  r = sqrt(-2.0 * ln(v + TINY))
+  r = sqrt(-2.0 * ln(v))
   result = r * cos(p)
 
 import maths/types


### PR DESCRIPTION
We make the uniform random number for the log function in the Box-Muller algorithm always non-zero.  For RngMilc6, rescale the value from uniform and remove the use of TINY.  For MRG32k3a, remove the use of TINY since the uniform already excludes zero and one.