### PR TITLE
New generic HMC API

### DIFF
--- a/src/examples/generichmc.nim
+++ b/src/examples/generichmc.nim
@@ -7,11 +7,11 @@ import hmc/[hmcAction]
 
 qexInit()
 
-# specify parameters
+# specify parameters; overrwide with -<option>:<value> on command line
 letParam:
   gaugeFilename = "checkpoint.lat"
   
-  lattice = @[8, 8, 8, 16]
+  lattice = @[8, 8, 8, 8]
 
   beta = 7.5
   mass = 0.005
@@ -19,21 +19,21 @@ letParam:
   massPV = 0.75
   
   numSt = 1 # number of staggered fermions
-  numPV = 0 # number of staggered Pauli-Villars
+  numPV = 8 # number of staggered Pauli-Villars
 
   start = "cold"
 
-  parallelSeed = 123456789
-  serialSeed = 123456789
+  parallelSeed = 987654321
+  serialSeed = 987654321
 
   outerIntegrator = "2MN"
   innerIntegrator = "2MN"
   outerSteps = 10
-  innerSteps = 10 # way too large, but good for testing
+  innerSteps = 10
 
   startTraj = 0
   numTraj = 1
-  trajectoryLength = 0.1 # way too small, but good for testing
+  trajectoryLength = 1.0
 
   actionMaxIter = 10000
   forceMaxIter = 10000
@@ -46,21 +46,26 @@ echo "rank ", myRank, "/", nRanks
 threads: echo "thread ", threadNum, "/", numThreads
 processHelpParam()
 
+# set up lattice layout
 let lo = lattice.newLayout()
+
+# set up random number generator
 var r = lo.newRNGField(RngMilc6, parallelSeed.uint64)
 var s: RngMilc6
 s.seed(serialSeed, 987654321)
 
+# set up gauge field and gauge configuration
 var 
   g = lo.newGauge()
   uc = newGaugeConfiguration(g)
 
+# initialize gauge configuration
 if start == "cold": uc.cold()
+elif start == "hot": uc.u.random(r)
 elif start == "read": uc.read(gaugeFilename)
-else:
-  qexError "invalid start type"
+else: qexError "invalid start type"
 
-#[ build staggered Dirac operators ]#
+#[ build staggered Dirac operator ]#
 
 when defined(HypSmearing):
   let stag = newStag(uc.su)
@@ -85,14 +90,14 @@ spf.verbosity = 1
 
 #[ build action in coordination with integrator levels ]#
 
-var gc = GaugeActionCoeffs(plaq: beta, rect: -beta/20.0)
+var gc = GaugeActionCoeffs(plaq: beta)
 var ga = gc.newGaugeAction()
 
 var fermionLevel = newActionLevel(multiplier = outerSteps, integrator = outerIntegrator)
 
 for i in 0..<numSt:
-  fermionLevel.add newStaggeredRatioAction(stag, stag, mass, massH, spa, spf)
   fermionLevel.add newStaggeredFermionAction(stag, massH, spa, spf)
+  fermionLevel.add newStaggeredRatioAction(stag, stag, mass, massH, spa, spf)
 
 for i in 0..<numPV:
   fermionLevel.add newStaggeredPauliVillarsAction(stag, massPV, spa, spf)

--- a/src/examples/generichmc.nim
+++ b/src/examples/generichmc.nim
@@ -1,0 +1,113 @@
+import qex
+
+import physics/[stagD]
+import physics/[stagSolve]
+
+import hmc/[hmcAction]
+
+qexInit()
+
+# specify parameters
+letParam:
+  gaugeFilename = "checkpoint.lat"
+  
+  lattice = @[8, 8, 8, 16]
+
+  beta = 7.5
+  mass = 0.005
+  massH = 0.6
+  massPV = 0.75
+  
+  numSt = 1 # number of staggered fermions
+  numPV = 0 # number of staggered Pauli-Villars
+
+  start = "cold"
+
+  parallelSeed = 123456789
+  serialSeed = 123456789
+
+  outerIntegrator = "2MN"
+  innerIntegrator = "2MN"
+  outerSteps = 10
+  innerSteps = 10 # way too large, but good for testing
+
+  startTraj = 0
+  numTraj = 1
+  trajectoryLength = 0.1 # way too small, but good for testing
+
+  actionMaxIter = 10000
+  forceMaxIter = 10000
+  actionTol = 1e-20
+  forceTol = 1e-13
+
+installStandardParams()
+echoParams()
+echo "rank ", myRank, "/", nRanks
+threads: echo "thread ", threadNum, "/", numThreads
+processHelpParam()
+
+let lo = lattice.newLayout()
+var r = lo.newRNGField(RngMilc6, parallelSeed.uint64)
+var s: RngMilc6
+s.seed(serialSeed, 987654321)
+
+var 
+  g = lo.newGauge()
+  uc = newGaugeConfiguration(g)
+
+if start == "cold": uc.cold()
+elif start == "read": uc.read(gaugeFilename)
+else:
+  qexError "invalid start type"
+
+#[ build staggered Dirac operators ]#
+
+when defined(HypSmearing):
+  let stag = newStag(uc.su)
+elif defined(StoutSmearing):
+  qexError "Stout smearing for HMC not yet implemented"
+elif defined(HisqSmearing): 
+  let stag = newStag3(uc.su, uc.sul)
+else: 
+  let stag = newStag(uc.u)
+
+var spa = initSolverParams()
+var spf = initSolverParams()
+
+spa.r2req = actionTol
+spf.r2req = forceTol
+
+spa.maxits = actionMaxIter
+spf.maxits = forceMaxIter
+
+spa.verbosity = 1
+spf.verbosity = 1
+
+#[ build action in coordination with integrator levels ]#
+
+var gc = GaugeActionCoeffs(plaq: beta, rect: -beta/20.0)
+var ga = gc.newGaugeAction()
+
+var fermionLevel = newActionLevel(multiplier = outerSteps, integrator = outerIntegrator)
+
+for i in 0..<numSt:
+  fermionLevel.add newStaggeredRatioAction(stag, stag, mass, massH, spa, spf)
+  fermionLevel.add newStaggeredFermionAction(stag, massH, spa, spf)
+
+for i in 0..<numPV:
+  fermionLevel.add newStaggeredPauliVillarsAction(stag, massPV, spa, spf)
+
+var gaugeLevel = newActionLevel(multiplier = innerSteps, integrator = innerIntegrator)
+gaugeLevel.add ga
+
+var hmc = uc.newHmcAction(s, r, trajectoryLength)
+hmc.add gaugeLevel   # inner level
+hmc.add fermionLevel # outer level
+
+#[ do HMC trajectory ]#
+
+hmc.init()
+hmc.verbosity = 1
+for traj in startTraj..<startTraj + numTraj: hmc.update()
+
+qexFinalize()

--- a/src/gauge/hisqsmear.nim
+++ b/src/gauge/hisqsmear.nim
@@ -6,7 +6,7 @@ import maths/[matproject]
 
 export hisqLinks
 
-proc asqtadDeriv[T](
+proc asqtadDeriv*[T](
     deriv: auto, 
     gauge,mid: T,  
     coef: Fat7lCoefs,
@@ -15,24 +15,28 @@ proc asqtadDeriv[T](
     perf: var PerfInfo
   ) =
   var (f,fll) = (newOneOf(mid),newOneOf(mid))
+  threads:
+    for mu in 0..<mid.len:
+      f[mu] := 0
+      fll[mu] := 0
   fat7lderiv(f,gauge,mid,coef,fll,llgauge,llmid,naik,perf)
   threads:
     for mu in 0..<mid.len:
       for s in deriv[mu]: deriv[mu][s] := f[mu][s] + fll[mu][s]
 
-proc fat7Deriv[T](
+proc fat7Deriv*[T](
     deriv: auto,
     gauge,mid: T,
     coef: Fat7lCoefs,
     perf: var PerfInfo
   ) = deriv.fat7lDeriv(gauge,mid,coef,perf)
 
-proc project[T](self: UnitaryProjection, v: auto; u: T) =
+proc project*[T](self: UnitaryProjection, v: auto; u: T) =
   threads:
     for mu in 0..<u.len:
       for s in u[mu]: self.projectU(v[mu][s], u[mu][s])
 
-proc projectDeriv[T](self: UnitaryProjection, dvdu: auto; v,u: T; chain: T) =
+proc projectDeriv*[T](self: UnitaryProjection, dvdu: auto; v,u: T; chain: T) =
   threads:
     for mu in 0..<chain.len:
       for s in chain[mu]:

--- a/src/hmc/hmcAction.nim
+++ b/src/hmc/hmcAction.nim
@@ -210,8 +210,7 @@ proc kineticAction*(hmc: HmcAction): float =
     for mu in 0..<hmc.p.len: p2t += hmc.p[mu].norm2
     threadBarrier()
     threadMaster: p2 = p2t
-  result = 0.5*p2 - 16.0*float(hmc.p[0].l.physVol)
-  echo "kinetic action: ", result
+  return 0.5*p2 - 16.0*float(hmc.p[0].l.physVol)
 
 proc action*(hmc: var HmcAction): float =
   result = 0.0
@@ -628,7 +627,7 @@ proc heatbath*(self: StaggeredPauliVillarsAction; u: GaugeConfiguration; rng: au
   threads: 
     psi.gaussian(rng)
     self.phi := 0
-  self.stag.solve(self.phi, psi, -self.mass, self.spa)
+  self.stag.solve(self.phi, psi, self.mass, self.spa)
   threads: self.phi.odd := 0
   u.setBC()
   u.stagPhase()
@@ -643,7 +642,7 @@ proc action*(self: StaggeredPauliVillarsAction; u: GaugeConfiguration): float =
   threads:
     psi := 0
     threadBarrier()
-    self.stag.D(psi, self.phi, -self.mass)
+    self.stag.D(psi, self.phi, self.mass)
     threadBarrier()
     var psi2t = psi.norm2()
     threadBarrier()

--- a/src/hmc/hmcAction.nim
+++ b/src/hmc/hmcAction.nim
@@ -1,0 +1,752 @@
+## Actions for HMC
+## 
+## Author: Curtis T. Peterson
+## 
+## Details:
+## Implements actions/forces for use in HMC. Based on many iterations/versions of 
+## similar code that Curtis, James Osborn, and Xiao-Yong Jin have written over the
+## years. Currently only implements gauge and staggered fermion actions without 
+## rooting. But the template is there for more complicated actions. Specifically, 
+## see https://github.com/ctpeterson/qex/tree/devel/src/mcmc for how to implement
+## rooted actions.
+
+import field
+import rng
+import layout
+
+import mdevolve
+
+import std/[os]
+
+import algorithms/[integrator]
+
+import base/[qexInternal]
+import base/[basicOps]
+
+import gauge/[gaugeAction]
+import gauge/[gaugeUtils]
+
+import gauge/[hypsmear]
+import gauge/[stoutsmear]
+import gauge/[hisqsmear]
+
+import physics/[stagD]
+import physics/[stagSolve]
+
+when defined(HisqSmearing):
+  import maths/[matproject]
+
+import hmc/[metropolis]
+
+export metropolis
+
+type ActionRoot* = ref object of RootObj
+  heatbathProc*: proc()
+  actionProc*: proc(): float
+  forceProc*: proc(dtau: float)
+  name*: string
+
+type GaugeConfiguration*[U] = ref object
+  u*: seq[U]
+  when defined(HypSmearing):
+    su*: seq[U]
+  elif defined(StoutSmearing):
+    discard
+  elif defined(HisqSmearing):
+    su*, sul*: seq[U]
+  
+  when defined(HypSmearing):
+    sc*: HypCoefs
+  elif defined(StoutSmearing):
+    discard
+  elif defined(HisqSmearing):
+    sc*: HisqCoefs
+
+  when defined(HypSmearing):
+    deriv*: proc(f: seq[U]; chain: seq[U])
+  elif defined(StoutSmearing):
+    discard
+  elif defined(HisqSmearing):
+    deriv*: proc(dsdu: var seq[U]; dsdsu, dsdsul: seq[U])
+
+type 
+  GaugeAction* = ref object of ActionRoot
+    gc*: GaugeActionCoeffs
+
+  StaggeredFermionAction*[U, T, S] = ref object of ActionRoot
+    mass*: float
+    stag*: Staggered[U, T]
+    phi*: S
+    spa*: SolverParams
+    spf*: SolverParams
+
+  StaggeredPauliVillarsAction*[U, T, S] = ref object of ActionRoot
+    mass*: float
+    stag*: Staggered[U, T]
+    phi*: S
+    spa*: SolverParams
+    spf*: SolverParams
+
+  StaggeredRatioAction*[U, T, S] = ref object of ActionRoot
+    massNum*: float
+    massDen*: float
+    stagNum*: Staggered[U, T]
+    stagDen*: Staggered[U, T]
+    phi*: S
+    spa*: SolverParams
+    spf*: SolverParams
+
+type
+  ActionLevel* = object
+    actions*: seq[ActionRoot]
+    multiplier*: int
+    integrator*: IntegratorProc
+  
+  HmcAction*[U] = ref object of MetropolisRootObj
+    tau*: float
+    uc*: GaugeConfiguration[U]
+    levels*: seq[ActionLevel]
+    p*: seq[U]
+    f*: seq[U]
+    bu*: seq[U]
+    binder: proc(a: ActionRoot, fp: ptr seq[U])
+    heatbathProc*: proc()
+    globalRandProc*: proc(): float
+
+proc newHmcAction*[U](
+  uc: GaugeConfiguration[U]; 
+  srng: auto; 
+  prng: auto; 
+  tau: float
+): HmcAction[U] =
+  new(result)
+  result.uc = uc
+  let lo = uc.u[0].l
+  result.p = lo.newGauge()
+  result.f = lo.newGauge()
+  result.bu = lo.newGauge()
+  template ET: untyped = evalType(lo.ColorVector()[0])
+  template FT: untyped = evalType(lo.ColorVector())
+
+  result.tau = tau
+
+  let pHB = result.p
+  result.heatbathProc = proc = 
+    var p = pHB
+    threads:
+      for mu in 0..<p.len: p[mu].randomTAH(prng)
+  
+  var sRng = srng
+  result.globalRandProc = proc(): float = sRng.uniform()
+
+  result.binder = proc(a: ActionRoot, fp: ptr seq[U]) =
+    case a.name
+    of "GaugeAction":
+      let ga = GaugeAction(a)
+      ga.heatbathProc = proc() = discard
+      ga.actionProc = proc(): float = ga.action(uc)
+      ga.forceProc = proc(dtau: float) =
+        let fi = ga.force(uc)
+        threads:
+          for mu in 0..<fp[].len: fp[][mu] += dtau * fi[mu]
+    of "StaggeredFermionAction":
+      let fa = StaggeredFermionAction[U, ET, FT](a)
+      fa.heatbathProc = proc() = fa.heatbath(uc, prng)
+      fa.actionProc = proc(): float = fa.action(uc)
+      fa.forceProc = proc(dtau: float) =
+        let fi = fa.force(uc)
+        threads:
+          for mu in 0..<fp[].len: fp[][mu] += dtau * fi[mu]
+    of "StaggeredPauliVillarsAction":
+      let pva = StaggeredPauliVillarsAction[U, ET, FT](a)
+      pva.heatbathProc = proc() = pva.heatbath(uc, prng)
+      pva.actionProc = proc(): float = pva.action(uc)
+      pva.forceProc = proc(dtau: float) =
+        let fi = pva.force(uc)
+        threads:
+          for mu in 0..<fp[].len: fp[][mu] += dtau * fi[mu]
+    of "StaggeredRatioAction":
+      let ra = StaggeredRatioAction[U, ET, FT](a)
+      ra.heatbathProc = proc() = ra.heatbath(uc, prng)
+      ra.actionProc = proc(): float = ra.action(uc)
+      ra.forceProc = proc(dtau: float) =
+        let fi = ra.force(uc)
+        threads:
+          for mu in 0..<fp[].len: fp[][mu] += dtau * fi[mu]
+    else: qexError "Unknown action type: " & a.name
+
+#[ ActionLevel: virtual dispatch for nested integrators ]#
+
+proc newActionLevel*(multiplier: int = 1; integrator: IntegratorProc = "2MN"): ActionLevel =
+  ActionLevel(actions: @[], multiplier: multiplier, integrator: integrator)
+
+proc add*(level: var ActionLevel; action: ActionRoot) =
+  level.actions.add(action)
+
+proc heatbath(level: ActionLevel) =
+  for a in level.actions: a.heatbathProc()
+
+proc action(level: ActionLevel): float =
+  for a in level.actions: result += a.actionProc()
+
+proc force(level: ActionLevel; dtau: float) =
+  for a in level.actions: a.forceProc(dtau)
+
+proc add*(hmc: var HmcAction; level: ActionLevel) =
+  let fp = addr hmc.f
+  for a in level.actions: hmc.binder(a, fp)
+  hmc.levels.add(level)
+
+proc heatbath(hmc: var HmcAction; rng: auto) =
+  var p = hmc.p
+  threads:
+    for mu in 0..<p.len: p[mu].randomTAH(rng)
+  for level in hmc.levels: level.heatbath()
+
+proc kineticAction*(hmc: HmcAction): float =
+  var p2: float
+  threads:
+    var p2t = 0.0
+    for mu in 0..<hmc.p.len: p2t += hmc.p[mu].norm2
+    threadBarrier()
+    threadMaster: p2 = p2t
+  result = 0.5*p2 - 16.0*float(hmc.p[0].l.physVol)
+  echo "kinetic action: ", result
+
+proc action*(hmc: var HmcAction): float =
+  result = 0.0
+  for level in hmc.levels: result += level.action()
+
+proc hamiltonian*(hmc: var HmcAction): float = hmc.kineticAction() + hmc.action()
+
+proc integrator*(hmc: var HmcAction): Integrator =
+  let uc = hmc.uc
+  let pp = addr hmc.p
+  let fp = addr hmc.f
+  let levels = addr hmc.levels
+  let nlevels = hmc.levels.len
+
+  proc mdt(dtau: float) =
+    threads:
+      for mu in 0..<uc.u.len:
+        for s in uc.u[mu]:
+          uc.u[mu][s] := exp(dtau * pp[][mu][s]) * uc.u[mu][s]
+
+  proc mdv(dtau: openArray[float]) =
+    threads:
+      for mu in 0..<fp[].len: fp[][mu] := 0
+    for i in 0..<nlevels:
+      if dtau[i] != 0.0: levels[][i].force(dtau[i])
+    threads:
+      for mu in 0..<pp[].len: pp[][mu] -= fp[][mu]
+
+  let (V, T) = newIntegratorPair(mdv, mdt)
+  var integrator = T
+  for i in 0..<nlevels:
+    integrator = levels[][i].integrator(
+      T = integrator, 
+      V = V[i], 
+      steps = levels[][i].multiplier
+    )
+  
+  return integrator
+
+proc setGauge[U](g: seq[U]; u: seq[U]) =
+  threads:
+    for mu in 0..<g.len: g[mu] := u[mu]
+
+proc reunit(g: auto) =
+  threads:
+    let d = g.checkSU
+    threadBarrier()
+    echo "unitary deviation avg: ",d.avg," max: ",d.max
+    g.projectSU
+    threadBarrier()
+    let dd = g.checkSU
+    echo "new unitary deviation avg: ",dd.avg," max: ",dd.max
+
+proc reunit*(hmc: var HmcAction) = reunit(hmc.uc.u)
+
+#[ "virtual" MetropolisRootObj procedures ]#
+
+proc getH*(hmc: var HmcAction): float = hmc.hamiltonian()
+
+proc start*(hmc: var HmcAction) =
+  hmc.heatbathProc()
+  for level in hmc.levels: level.heatbath()
+  setGauge(hmc.bu, hmc.uc.u)
+
+proc generate*(hmc: var HmcAction) =
+  var integ = hmc.integrator()
+  integ.evolve(hmc.tau)
+  integ.finish()
+
+proc globalRand*(hmc: var HmcAction): float = hmc.globalRandProc()
+
+proc accept*(hmc: var HmcAction) = hmc.reunit()
+
+proc reject*(hmc: var HmcAction) = setGauge(hmc.uc.u, hmc.bu)
+
+#[ gauge configuration implementation ]#
+
+when defined(HypSmearing):
+  proc newGaugeConfiguration*[U](
+    u: seq[U];
+    alpha1: float = 0.4;
+    alpha2: float = 0.5;
+    alpha3: float = 0.5
+  ): GaugeConfiguration[U] =
+    let lo = u[0].l
+    result = GaugeConfiguration[U](u: u)
+    result.sc = HypCoefs(alpha1: alpha1, alpha2: alpha2, alpha3: alpha3)
+    result.su = lo.newGauge()
+elif defined(StoutSmearing):
+  proc newGaugeConfiguration*[U](u: seq[U]): GaugeConfiguration[U] =
+    qexError "Stout smearing for HMC not yet implemented"
+elif defined(HisqSmearing):
+  proc newGaugeConfiguration*[U](
+    u: seq[U];
+    naik: float = 1.0;
+    lepage: float = 0.0;
+    unitaryItr: int = 10;
+    unitaryEps: float = 1e-20;
+    unitaryPrj: ProjectionMethod = CayleyHamilton
+  ): GaugeConfiguration[U] =
+    let lo = u[0].l
+    result = GaugeConfiguration[U](u: u)
+
+    result.sc = HisqCoefs()
+    result.sc.fat7first.setHisqFat7(lepage, 0.0)
+    result.sc.fat7second.setHisqFat7(2.0 - lepage, naik)
+    result.sc.naik = -naik/24.0
+    result.sc.projection = newUnitaryProjection(unitaryPrj, unitaryEps, unitaryItr)
+    
+    result.su = lo.newGauge()
+    result.sul = lo.newGauge()
+else:
+  proc newGaugeConfiguration*[U](u: seq[U]): GaugeConfiguration[U] =
+    result = GaugeConfiguration[U](u: u)
+
+proc cold*(c: var GaugeConfiguration) = c.u.unit()
+
+proc read*(c: var GaugeConfiguration; filename: string) =
+  if fileExists(filename):
+    if 0 != c.u.loadGauge(filename):
+      qexError "error loading gauge configuration from file: ", filename
+    qexLog "gauge configuration loaded from file: ", filename
+  else: qexError "gauge configuration file does not exist: ", filename
+
+proc smear(self: GaugeConfiguration) =
+  # HISQ is a staggered smearing, so I don't mind having to explicitly insert the 
+  # the staggered rephasing here. For other smearings, rephasing must be decoupled
+  # from the smearing, which is the case for nHYP
+  when defined(HypSmearing):
+    var info: PerfInfo
+    discard self.sc.smearGetForce(self.u, self.su, info)
+  elif defined(StoutSmearing):
+    qexError "Stout smearing for HMC not yet implemented"
+  elif defined(HisqSmearing):
+    threads: 
+      self.u.setBC()
+      threadBarrier()
+      self.u.stagPhase()
+    discard self.sc.smearGetForce(self.u, self.su, self.sul)
+    threads:
+      self.u.setBC()
+      threadBarrier()
+      self.u.stagPhase()
+
+proc smearGetForce[U](self: GaugeConfiguration[U]) =
+  when defined(HypSmearing): 
+    var info: PerfInfo
+    self.deriv = self.sc.smearGetForce(self.u, self.su, info)
+  elif defined(StoutSmearing): 
+    qexError "Stout smearing for HMC not yet implemented"
+  elif defined(HisqSmearing):
+    threads:
+      self.u.setBC()
+      threadBarrier()
+      self.u.stagPhase()
+    self.deriv = self.sc.smearGetForce(self.u, self.su, self.sul)
+    threads:
+      self.u.setBC()
+      threadBarrier()
+      self.u.stagPhase()
+
+proc setBC[U](self: GaugeConfiguration[U]) =
+  threads:
+    when defined(HypSmearing): self.su.setBC()
+    elif defined(StoutSmearing): qexError "Stout smearing for HMC not yet implemented"
+    elif defined(HisqSmearing): discard
+    else: self.u.setBC()
+
+proc stagPhase[U](self: GaugeConfiguration[U]) =
+  threads:
+    when defined(HypSmearing): self.su.stagPhase()
+    elif defined(StoutSmearing): qexError "Stout smearing for HMC not yet implemented"
+    elif defined(HisqSmearing): discard
+    else: self.u.stagPhase()
+
+#[ gauge action implementation ]#
+
+proc newGaugeAction*(gc: GaugeActionCoeffs): GaugeAction =
+  result = GaugeAction(gc: gc)
+  result.name = "GaugeAction"
+
+proc action*(self: GaugeAction; u: GaugeConfiguration): float = 
+  return self.gc.gaugeAction1(u.u)
+  
+proc force*(self: GaugeAction; u: GaugeConfiguration): auto = 
+  let lo = u.u[0].l
+  var f = lo.newGauge()
+  self.gc.gaugeForce(u.u, f)
+  return f
+
+#[ fermion force helpers ]#
+
+proc stagForceSolve[T](
+  stag: auto; 
+  psi: auto; 
+  phi: T; 
+  mass: float; 
+  sp0: var SolverParams
+) =
+  tic()
+  var
+    varphi = newOneOf(psi)
+    r = newOneOf(phi)
+    r2, b2: float
+    sp = sp0
+
+  # Prepare solver parameters
+  sp.resetStats()
+  dec sp.verbosity
+  sp.usePrevSoln = false
+  threads:
+    psi := 0
+    varphi := 0
+    r := 0
+    let b2t = phi.norm2
+    threadBarrier()
+    threadMaster: b2 = b2t
+
+  # Get solution
+  stag.solveEE(varphi, phi, mass, sp)
+  threads:
+    # Get residual
+    var r2t: float
+    stagD2ee(stag.se, stag.so, r, stag.g, varphi, mass*mass)
+    threadBarrier()
+    r := r - phi
+    threadBarrier()
+    r2t = r.norm2
+    threadBarrier()
+    threadMaster: r2 = r2t
+
+    # Get solution for force
+    varphi.even := 4.0*varphi
+    threadBarrier()
+    stagD2(stag.so, psi, stag.g, varphi, 0, 0)
+    threadBarrier()
+    psi.even := varphi
+
+  # Get information about solve
+  sp.r2.init r2/b2
+  sp.calls = 1
+  sp.seconds = getElapsedTime()
+  sp.flops += float((stag.g.len*4*72+24)*psi.l.nEven) # ???
+  if sp0.verbosity>0: echo "stagSolve: ", sp.getStats
+  sp0.addStats(sp)
+
+proc fermForce[U, S](f: seq[U]; psi: S; u: GaugeConfiguration[U]) =
+  let nc = psi[0].len
+  let nd = psi.l.nDim
+  var
+    ff = f.newOneOf()
+    f1 = f.newOneOf()
+    t1 = newSeq[Shifter[typeOf(psi), typeOf(psi[0])]](nd) 
+  when defined(HisqSmearing):
+    var
+      f3 = f.newOneOf()
+      t3 = newSeq[Shifter[typeOf(psi), typeOf(psi[0])]](nd)
+
+  for mu in 0..<nd:
+    t1[mu] = newShifter(psi, mu, 1)
+    discard t1[mu] ^* psi
+    when defined(HisqSmearing):
+      t3[mu] = newShifter(psi, mu, 3)
+      discard t3[mu] ^* psi
+  
+  # dslash
+  threads:
+    for mu in 0..<nd:
+      for n in f[mu]:
+        forO a, 0, nc-1:
+          forO b, 0, nc-1:
+            f1[mu][n][a, b] := psi[n][a] * t1[mu].field[n][b].adj
+            when defined(HisqSmearing):
+              f3[mu][n][a, b] := psi[n][a] * t3[mu].field[n][b].adj
+        f[mu][n] := 0
+        ff[mu][n] := 0
+    threadBarrier()
+
+    # rephase
+    when defined(HypSmearing):
+      f1.setBC()
+      threadBarrier()
+      f1.stagPhase()
+    elif defined(StoutSmearing):
+      qexError "Stout smearing for HMC not yet implemented"
+    elif defined(HisqSmearing):
+      u.u.setBC()
+      threadBarrier()
+      u.u.stagPhase()
+    # else: u rephasing already takes care of phases
+    threadBarrier()
+
+    # correct odd sites
+    for mu in 0..<nd:
+      for n in f[mu].odd:
+        f1[mu][n] *= -1
+        when defined(HisqSmearing):
+          f3[mu][n] *= -1
+  
+  # smear
+  when defined(HypSmearing): u.deriv(ff, f1)
+  elif defined(StoutSmearing): qexError "Stout smearing for HMC not yet implemented"
+  elif defined(HisqSmearing): u.deriv(ff, f1, f3)
+  else: # no smearing - identity chain rule
+    threads:
+      for mu in 0..<ff.len: ff[mu] := f1[mu]
+
+  # traceless/anti-Hermitian projection
+  threads:
+    for mu in 0..<f.len:
+      for n in f[mu]: f1[mu][n] := ff[mu][n] * u.u[mu][n].adj
+    threadBarrier()
+    when defined(HisqSmearing):
+      u.u.setBC()
+      threadBarrier()
+      u.u.stagPhase()
+    for mu in 0..<f.len:
+      for n in f[mu]: f[mu][n].projectTAH(f1[mu][n])
+
+#[ staggered fermion action ]#
+
+proc newStaggeredFermionAction*[U, T](
+  stag: Staggered[U, T]; 
+  mass: float;
+  spa: SolverParams;
+  spf: SolverParams
+): auto = 
+  let lo = stag.g[0].l
+  var phi = lo.ColorVector()
+  let self = StaggeredFermionAction[U, T, evalType(phi)](
+    mass: mass, 
+    stag: stag, 
+    phi: phi, 
+    spa: spa, 
+    spf: spf
+  )
+  self.name = "StaggeredFermionAction"
+  return self
+
+proc heatbath*(self: StaggeredFermionAction; u: GaugeConfiguration; rng: auto) =
+  let lo = self.phi.l
+  var psi = lo.ColorVector()
+  u.smear()
+  u.setBC()
+  u.stagPhase()
+  threads: 
+    psi.gaussian(rng)
+    threadBarrier()
+    self.stag.D(self.phi, psi, -self.mass)
+    threadBarrier()
+    self.phi.odd := 0
+  u.setBC()
+  u.stagPhase()
+
+proc action*(self: StaggeredFermionAction; u: GaugeConfiguration): float =
+  let lo = self.phi.l
+  var psi = lo.ColorVector()
+  var psi2: float
+  threads: psi := 0
+  u.smear()
+  u.setBC()
+  u.stagPhase()
+  self.stag.solve(psi, self.phi, -self.mass, self.spa)
+  threads:
+    var psi2t = psi.norm2()
+    threadBarrier()
+    threadMaster: psi2 = psi2t
+  u.setBC()
+  u.stagPhase()
+  return 0.5*psi2
+
+proc force*[U](self: StaggeredFermionAction; u: GaugeConfiguration[U]): auto =
+  let lo = self.phi.l
+  var f = lo.newGauge()
+  var psi = lo.ColorVector()
+  u.smearGetForce()
+  u.setBC()
+  u.stagPhase()
+  self.stag.stagForceSolve(psi, self.phi, self.mass, self.spf)
+  f.fermForce(psi, u)
+  u.setBC()
+  u.stagPhase()
+  threads:
+    for mu in 0..<f.len:
+      for n in f[mu]: f[mu][n] *= 0.25
+  return f
+
+#[ staggered Pauli-Villars action ]#
+
+proc newStaggeredPauliVillarsAction*[U, T](
+  stag: Staggered[U, T]; 
+  mass: float;
+  spa: SolverParams;
+  spf: SolverParams
+): auto = 
+  let lo = stag.g[0].l
+  var phi = lo.ColorVector()
+  let self = StaggeredPauliVillarsAction[U, T, evalType(phi)](
+    mass: mass, 
+    stag: stag, 
+    phi: phi, 
+    spa: spa, 
+    spf: spf
+  )
+  self.name = "StaggeredPauliVillarsAction"
+  return self
+
+proc heatbath*(self: StaggeredPauliVillarsAction; u: GaugeConfiguration; rng: auto) =
+  let lo = self.phi.l
+  var psi = lo.ColorVector()
+  u.smear()
+  u.setBC()
+  u.stagPhase()
+  threads: 
+    psi.gaussian(rng)
+    self.phi := 0
+  self.stag.solve(self.phi, psi, -self.mass, self.spa)
+  threads: self.phi.odd := 0
+  u.setBC()
+  u.stagPhase()
+
+proc action*(self: StaggeredPauliVillarsAction; u: GaugeConfiguration): float =
+  let lo = self.phi.l
+  var psi = lo.ColorVector()
+  var psi2: float
+  u.smear()
+  u.setBC()
+  u.stagPhase()
+  threads:
+    psi := 0
+    threadBarrier()
+    self.stag.D(psi, self.phi, -self.mass)
+    threadBarrier()
+    var psi2t = psi.norm2()
+    threadBarrier()
+    threadMaster: psi2 = psi2t
+  u.setBC()
+  u.stagPhase()
+  return 0.5*psi2
+
+proc force*[U](self: StaggeredPauliVillarsAction; u: GaugeConfiguration[U]): auto =
+  let lo = self.phi.l
+  var f = lo.newGauge()
+  var psi = lo.ColorVector()
+  u.smearGetForce()
+  u.setBC()
+  u.stagPhase()
+  threads:
+    psi := 0
+    threadBarrier()
+    stagD2(self.stag.so, psi, self.stag.g, self.phi, 0, 0)
+    threadBarrier()
+    psi.even := self.phi
+  f.fermForce(psi, u)
+  u.setBC()
+  u.stagPhase()
+  threads:
+    for mu in 0..<f.len:
+      for n in f[mu]: f[mu][n] *= -0.25
+  return f
+
+#[ staggered "ratio" (Pauli-Villars/fermion) action ]#
+
+proc newStaggeredRatioAction*[U, T](
+  stagNum: Staggered[U, T]; 
+  stagDen: Staggered[U, T]; 
+  massNum: float;
+  massDen: float;
+  spa: SolverParams;
+  spf: SolverParams
+): auto = 
+  let lo = stagNum.g[0].l
+  var phi = lo.ColorVector()
+  let self = StaggeredRatioAction[U, T, evalType(phi)](
+    massNum: massNum, 
+    massDen: massDen,
+    stagNum: stagNum, 
+    stagDen: stagDen,
+    phi: phi, 
+    spa: spa, 
+    spf: spf
+  )
+  self.name = "StaggeredRatioAction"
+  return self
+
+proc heatbath*(self: StaggeredRatioAction; u: GaugeConfiguration; rng: auto) =
+  let lo = self.phi.l
+  var psi = lo.ColorVector()
+  var phi = lo.ColorVector()
+  u.smear()
+  u.setBC()
+  u.stagPhase()
+  threads: 
+    self.phi := 0
+    psi.gaussian(rng)
+    threadBarrier()
+    self.stagNum.D(phi, psi, -self.massNum)
+  self.stagDen.solve(self.phi, phi, -self.massDen, self.spa)
+  threads: self.phi.odd := 0
+  u.setBC()
+  u.stagPhase()
+
+proc action*(self: StaggeredRatioAction; u: GaugeConfiguration): float =
+  let lo = self.phi.l
+  var psi = lo.ColorVector()
+  var phi = lo.ColorVector()
+  var psi2: float
+  u.smear()
+  u.setBC()
+  u.stagPhase()
+  threads:
+    self.stagDen.D(phi, self.phi, -self.massDen)
+    psi := 0
+  self.stagNum.solve(psi, phi, -self.massNum, self.spa)
+  threads:
+    var psi2t = psi.norm2()
+    threadBarrier()
+    threadMaster: psi2 = psi2t
+  u.setBC()
+  u.stagPhase()
+  return 0.5*psi2
+  
+proc force*[U](self: StaggeredRatioAction; u: GaugeConfiguration[U]): auto =
+  let lo = self.phi.l
+  var f = lo.newGauge()
+  var psi = lo.ColorVector()
+  u.smearGetForce()
+  u.setBC()
+  u.stagPhase()
+  self.stagNum.stagForceSolve(psi, self.phi, self.massNum, self.spf)
+  f.fermForce(psi, u)
+  u.setBC()
+  u.stagPhase()
+  let ffac = 0.25 * (self.massDen*self.massDen - self.massNum*self.massNum)
+  threads:
+    for mu in 0..<f.len:
+      for n in f[mu]: f[mu][n] *= ffac
+  return f

--- a/src/hmc/metropolis.nim
+++ b/src/hmc/metropolis.nim
@@ -1,5 +1,5 @@
 import strUtils
-import comms/commsUtils, math, strformat, stats
+import comms/[commsUtils, commsEcho], math, strformat, stats
 
 type
   MetropolisStats* = object


### PR DESCRIPTION
This PR adds a new API for doing HMC with multi-level ("recursive") integrators. The API is modeled after [Grid](https://github.com/paboyle/Grid)'s HMC API. The main ingredients are as follows.

See [generichmc.nim](https://github.com/jcosborn/qex/blob/feature/hmc/src/examples/generichmc.nim) for an example use of this API.

1.) Actions: for now, GaugeAction, StaggeredFermionAction, StaggeredPauliVillarsAction, and StaggeredRatioAction. These all have their own procedures for the heatbath, action, and force
  a.) GaugeAction: exactly what you think
  b.) StaggeredFermionAction: exactly what you think
  c.) StaggeredPauliVillarsAction: just a Pauli-Villars action
  d.) StaggeredRatioAction: action with ratio of Dirac operators. Full Hasenbusch combines one StaggeredFermionAction and one StaggeredRatioAction; this can be chained for multiple Hasenbusch.
2.) ActionLevel: a container that stores a collection of actions and represents one level of a multi-level integrator.
3.) HmcAction: container that stores multiple action levels. It is a ref object of MetropolisRootObj, so it also drives the HMC. 

Two important notes:

1.) The smearing is applied as a policy at compile time. This makes the code much more readable and less complicated. I've tried applying it as a generic parameter, and that gets very complicated very fast. HYP smearing is selected by the :HypSmearing flag, HISQ is :HisqSmearing, and stout (just a placeholder) is :StoutSmearing; no smearing is applied otherwise.
2.) You'll notice that I restrict to multi-level (recursive) integrators, as opposed to the "concatenated" integrators that MDevolve also supports and put a lot of effort into. I did this because it simplifies the code and I also tend to find that the recursive integrators both perform better and are more reliable than the concatenated integrators.

Adding stout smearing will be simple. It is currently a placeholder. 

Rooted actions + Wilson should also be simple to add. For the rooted actions, I'd just follow what I already did [here](https://github.com/ctpeterson/qex/blob/devel/src/mcmc/fields/staggeredFields.nim), just less convoluted.

The correctness of this code has been validated against *both* the HISQ and nHYP compilation paths of the [FNAL/MILC fork of QEX](https://github.com/milc-qcd/qex/tree/devel/src/alphas); this validates the Hasenbusch HMC with a single staggered fermion field using both smearings. It has also been validated against the [old HMC code](https://github.com/jcosborn/qex/tree/staghmc-devel/src/stagg_pv_hmc) currently being used by LSD for studying symmetric mass generation in the eight flavor system; this validates Hasenbusch HMC w/ Pauli-Villars using nHYP smearing. The no-smearing path has not been validated against existing code; however, it appears to be producing reasonable results, but caution should be used. 

Finally, this PR ships with an additional bug fix to the HISQ smearing that was introduced earlier this year when default initialization was removed from all field types.